### PR TITLE
Fix bug in myeloid coverage (issue 26)

### DIFF
--- a/analysis/utils.py
+++ b/analysis/utils.py
@@ -513,32 +513,40 @@ def myeloid_format_output(input_dict):
             codons = []
             exons = []
             for r in regions:
-                region, num = r.split(' ')
+                region = r.split(' ')[0]
+                num = r.split(' ')[1]
                 if region == 'exon':
                     exons.append(int(num))
                 elif region == 'codon':
                     codons.append(num)
 
-            # empty string to build output
-            all_regions = ''
+            # empty list to build output
+            all_regions_list = []
 
-            # add codons to string first, if there are any (these arent sorted if there are multiple)
+            # add codons to list first, if there are any (these arent sorted if there are multiple)
             if codons:
-                all_regions += f'codon {", ".join(codons)}, '
+                all_codons = f'codon {", ".join(codons)}'
+                all_regions_list.append(all_codons)
 
-            # add exons to string if there are any
+            # add exons to list if there are any
             if exons:
 
                 # handle pluralisation of word exon
                 if len(exons) == 1:
-                    all_regions += 'exon '
+                    all_exons = 'exon '
                 else:
-                    all_regions += 'exons '
+                    all_exons = 'exons '
 
                 # sort and concatenate all exons
                 exons_str = [str(exon) for exon in sorted(exons)]
-                all_regions += ', '.join(exons_str)
-                
+                all_exons += ', '.join(exons_str)
+
+                # add to list
+                all_regions_list.append(all_exons)
+
+            # combine codon and exon lists into one
+            all_regions = ', '.join(all_regions_list)
+
             # add to the output list. if the transcript isnt a primary transcript, add the transcript ID in brackets after the gene name
             if transcript in alt_transcripts:
                 out_list.append(f'{gene} ({transcript}) {all_regions}')


### PR DESCRIPTION
## Change description
Committing to main as change required urgently

Further bug following on from same issue, one region annotation was called `exon 4 (partial)`, when split by whitespace it gave 3 variables compared to the usual two. Line 516 requires specifically 2 variables from the split command:

https://github.com/AWGL/somatic_db/blob/da3822372cc90156e38795e5e5cd9b42d2670ad8/analysis/utils.py#L516

This was fixed by explicitly calling the first and second record in the list:

https://github.com/AWGL/somatic_db/blob/7be5ccc436225a7651167634232fcb8c8a3722f8/analysis/utils.py#L516
https://github.com/AWGL/somatic_db/blob/7be5ccc436225a7651167634232fcb8c8a3722f8/analysis/utils.py#L517

Also reformatted the output due to an unwanted trailing comma in the codon section

## Testing description
- Manual check against coverage values

## Test data location
See CG-22-274-GEN writeup & PR #27 

## Verification results
See CG-22-274-GEN writeup & PR #27 