### PR TITLE
Bug fix

### DIFF
--- a/analysis/forms.py
+++ b/analysis/forms.py
@@ -67,9 +67,9 @@ class SubmitForm(forms.Form):
     """
     """
     NEXT_STEP_CHOICES = (
-        ('Complete check', 'Sample passed and check complete'),
-        ('Request extra check', 'Sample passed, check complete but extra check required (dont do this at first check)'),
-        ('Fail sample', 'Sample failed analysis but check is complete'),
+        ('Complete check', 'Sample passed check'),
+        ('Request extra check', 'Sample passed check, send for an extra check'),
+        ('Fail sample', 'Sample failed check'),
     )
     next_step = forms.ChoiceField(choices=NEXT_STEP_CHOICES)
     confirm = forms.BooleanField(required=True, label="Confirm check is complete")

--- a/analysis/templates/analysis/analysis-report-dna.html
+++ b/analysis/templates/analysis/analysis-report-dna.html
@@ -59,7 +59,7 @@
       <td>{{ v.gene }} ({{ v.exon }})</td>
       <td>{{ v.hgvs_c }}</td>
       <td>{{ v.hgvs_p }}</td>
-      <td>{{ v.vaf.vaf }}%</td>
+      <td>{{ v.vaf.vaf_rounded }}%</td>
       <td>{{ v.final_decision }}</td>
       <td>
       {% for c in v.comments %}

--- a/analysis/templates/analysis/download_dna_report.html
+++ b/analysis/templates/analysis/download_dna_report.html
@@ -87,7 +87,7 @@
         <td>{{ v.genomic | truncatechars:20 }}</td>
         <td>{{ v.gene }} ({{ v.exon }})</td>
         <td>{{ v.hgvs_c }} ({{ v.hgvs_p }})</td>
-        <td>{{ v.vaf.vaf }}%</td>
+        <td>{{ v.vaf.vaf_rounded }}%</td>
         <td>{{ v.final_decision }}</td>
         <td>
           {% for c in v.comments %}

--- a/analysis/utils.py
+++ b/analysis/utils.py
@@ -273,6 +273,10 @@ def get_variant_info(sample_data, sample_obj):
                     { 'comment': v.comment, 'user': v.check_object.user, 'updated': v.comment_updated, }
                 )
 
+        # get VAF and round to nearest whole number
+        vaf = sample_variant.variant_instance.vaf()
+        vaf_rounded = vaf.quantize(decimal.Decimal('1'), rounding=decimal.ROUND_HALF_UP)
+
         #Create a variant calls dictionary to pass to analysis-snvs.html
         variant_calls_dict = {
             'pk': sample_variant.pk,
@@ -296,7 +300,8 @@ def get_variant_info(sample_data, sample_obj):
                 'count': 'N/A', #previous_runs,
             },
             'vaf': {
-                'vaf': sample_variant.variant_instance.vaf(),
+                'vaf': vaf,
+                'vaf_rounded': vaf_rounded,
                 'total_count': sample_variant.variant_instance.total_count,
                 'alt_count': sample_variant.variant_instance.alt_count,
             },

--- a/analysis/views.py
+++ b/analysis/views.py
@@ -66,7 +66,7 @@ def view_worksheets(request, query):
     """
     # based on URL, either query 30 most recent or all results
     if query == 'recent':
-        worksheets = Worksheet.objects.all().order_by('-run')[:30]
+        worksheets = Worksheet.objects.filter(diagnostic=True).order_by('-run')[:30]
         filtered = True
 
     elif query == 'all':
@@ -350,8 +350,6 @@ def analysis_sheet(request, sample_id):
 
                 new_variant_data = new_variant_form.cleaned_data
 
-                vaf = int((new_variant_data['alt_reads'] / new_variant_data['total_reads']) * 100)
-
                 new_variant_object, created = Variant.objects.get_or_create(
                     genomic_37 = new_variant_data['hgvs_g'],
                     genomic_38 = None,
@@ -364,7 +362,6 @@ def analysis_sheet(request, sample_id):
                     hgvs_c = new_variant_data['hgvs_c'],
                     hgvs_p = new_variant_data['hgvs_p'],
                     sample = sample_obj.sample, 
-                    vaf = vaf, 
                     total_count = new_variant_data['total_reads'], 
                     alt_count = new_variant_data['alt_reads'], 
                     in_ntc = new_variant_data['in_ntc'], 


### PR DESCRIPTION
## Change description
Bug fixes to live copy of the database that were needed after deployment
- Reword the submit dropdown again, the wording was confusing
- add filter for diagnostic runs on worksheets page rather than show all
- Add VAF rounded to whole number for the PDF report download and the report summary page, variant analysis page stays as 2dp

## Testing description
- Manual check of the database
  - Check the dropdown wording is as expected
  - Check that worksheet filtering and ordering is correct - there shouldnt be any training runs on the recent worksheets page
  - Check that VAFs are rounded to the nearest whole number on the report summary and PDF of completed analyses (0.5 rounds up, confirmed by SL), VAFs for the SNV analysis tab are rounded to 2bp.

## Test data location
N/A

## Verification results
All checks pass