### PR TITLE
Prevent upload of worksheet if already present with different seq run

### DIFF
--- a/analysis/management/commands/import.py
+++ b/analysis/management/commands/import.py
@@ -180,6 +180,16 @@ class Command(BaseCommand):
             genome_build = 37
         else:
             raise IOError(f'Genome build {genome} is neither GRCh37 or GRCh38')
+            
+        #Check that worksheet not already uploaded with another sequencing run
+        exist_worksheets = Worksheet.objects.filter(ws_id = ws)
+        
+        if len(exist_worksheets) != 0:
+        
+        	for worksheet in exist_worksheets:
+        	
+        		if worksheet.run.run_id != run_id:
+        			raise IOError(f'Worksheet {ws} uploaded already on another sequencing run {worksheet.run.run_id}. Please edit worksheet ID and try again e.g. {ws}R')
 
 
         # ---------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Fix for issue https://github.com/AWGL/somatic_db/issues/58 to prevent a worksheet from being uploaded if it already exists on another sequencing run. Prevents accidental merging of two sequencing run. 

Unit tests run end to end. 

Two runs with same worksheet are on portable hard drive under SVD_Test/ for testing. 