### PR TITLE
Issue75

### DIFF
--- a/analysis/forms.py
+++ b/analysis/forms.py
@@ -58,7 +58,7 @@ class NewVariantForm(forms.Form):
 
     """
 
-    chrm = forms.IntegerField(label='Chromosome')
+    chrm = forms.CharField(label='Chromosome')
     position = forms.IntegerField(label='Genomic coordinates')
     ref = forms.CharField(label='Reference nucleotide')
     alt = forms.CharField(label='Alt nucleotide')

--- a/analysis/forms.py
+++ b/analysis/forms.py
@@ -54,10 +54,14 @@ class PaperworkCheckForm(forms.Form):
 
 class NewVariantForm(forms.Form):
     """
-    Manually add a SNV
+    Manually add a SNV. Splitting HGVS into components to stop formatting errors
 
     """
-    hgvs_g = forms.CharField(label='Genomic coordinates')
+
+    chrm = forms.IntegerField(label='Chromosome')
+    position = forms.IntegerField(label='Genomic coordinates')
+    ref = forms.CharField(label='Reference nucleotide')
+    alt = forms.CharField(label='Alt nucleotide')
     hgvs_c = forms.CharField(label='HGVS c.')
     hgvs_p = forms.CharField(label='HGVS p.')
     gene = forms.CharField()
@@ -70,7 +74,10 @@ class NewVariantForm(forms.Form):
         super(NewVariantForm, self).__init__(*args, **kwargs)
         self.helper = FormHelper()
         self.helper.form_id = 'new-variant-form'
-        self.fields['hgvs_g'].widget.attrs['placeholder'] = 'e.g. 7:140453136A>T'
+        self.fields['chrm'].widget.attrs['placeholder'] = 'e.g. 7'
+        self.fields['position'].widget.attrs['placeholder'] = 'e.g. 140453136'
+        self.fields['ref'].widget.attrs['placeholder'] = 'e.g. A'
+        self.fields['alt'].widget.attrs['placeholder'] = 'e.g. T'
         self.fields['hgvs_c'].widget.attrs['placeholder'] = 'e.g. NM_004333.4:c.1799T>A'
         self.fields['hgvs_p'].widget.attrs['placeholder'] = 'e.g. NP_004324.2:p.(Val600Glu)'
         self.fields['gene'].widget.attrs['placeholder'] = 'e.g. BRAF'

--- a/analysis/templates/analysis/analysis-report.html
+++ b/analysis/templates/analysis/analysis-report.html
@@ -85,10 +85,13 @@
           <td class="variant-pk" style="display:none">{{ v.pk }}</td>
           <td><p style="display:inline" id="igv">{{ v.genomic }} 
             {% if v.genome_build == 37 %}
-            <span class = "badge badge-info badge-pill">GRCh{{ v.genome_build }}
+            <span class = "badge badge-info badge-pill">GRCh{{ v.genome_build }}</span>
             {% elif v.genome_build == 38 %}
-            <span class = "badge badge-success badge-pill">GRCh{{ v.genome_build }}
+            <span class = "badge badge-success badge-pill">GRCh{{ v.genome_build }}</span>
             {% endif %}
+            {% if v.manual_upload %}
+            <span class="badge badge-warning badge-pill">Manual</span>
+        {% endif %}
           </p></td>
           <td>{{ v.gene }} ({{ v.exon }})</td>
           <td>{{ v.hgvs_c }}</td>

--- a/analysis/templates/analysis/download_report.html
+++ b/analysis/templates/analysis/download_report.html
@@ -96,7 +96,11 @@
       {% for v in variant_data.variant_calls %}
         {% if v.final_decision == "Genuine" or v.final_decision == "Miscalled" %}
         <tr>
-          <td>{{ v.genomic | truncatechars:20 }}</td>
+          <td>{{ v.genomic | truncatechars:20 }}
+          {% if v.manual_upload %}
+        	Manual
+          {% endif %}
+          </td>
           <td>{{ v.gene }} ({{ v.exon }})</td>
           <td>{{ v.hgvs_c }} ({{ v.hgvs_p }})</td>
           {% if sample_data.panel_obj.assay == '3' %} <!-- 2dp for ctDNA, whole number for the rest-->

--- a/analysis/templates/analysis/download_report.html
+++ b/analysis/templates/analysis/download_report.html
@@ -213,7 +213,7 @@
         {% for gap in values.gaps_135 %}
         <tr>
           <td>{{ gap.hgvs_c }}</td>
-          <td>{{ gap.percent_cosmic }}%</td>
+          <td>{{ gap.percent_cosmic }}</td>
           <td>{{ gap.counts_cosmic }}</td>
         </tr>
         {% endfor %}
@@ -242,7 +242,7 @@
         {% for gap in values.gaps_270 %}
         <tr>
           <td>{{ gap.hgvs_c }}</td>
-          <td>{{ gap.percent_cosmic }}%</td>
+          <td>{{ gap.percent_cosmic }}</td>
           <td>{{ gap.counts_cosmic }}</td>
         </tr>
         {% endfor %}
@@ -271,7 +271,7 @@
         {% for gap in values.gaps_500 %}
         <tr>
           <td>{{ gap.hgvs_c }}</td>
-          <td>{{ gap.percent_cosmic }}%</td>
+          <td>{{ gap.percent_cosmic }}</td>
           <td>{{ gap.counts_cosmic }}</td>
         </tr>
         {% endfor %}
@@ -300,7 +300,7 @@
         {% for gap in values.gaps_1000 %}
         <tr>
           <td>{{ gap.hgvs_c }}</td>
-          <td>{{ gap.percent_cosmic }}%</td>
+          <td>{{ gap.percent_cosmic }}</td>
           <td>{{ gap.counts_cosmic }}</td>
         </tr>
         {% endfor %}

--- a/analysis/tests.py
+++ b/analysis/tests.py
@@ -1072,28 +1072,32 @@ class TestDna(TestCase):
         panel_obj = Panel.objects.get(panel_name='Lung', assay='1', genome_build=37, live=True)
         
         #Correct format
-        variant1_check, error = variant_format_check(7, 55241609, 'A', 'T', panel_obj.bed_file.path, 100, 10)
+        variant1_check, error = variant_format_check('7', 55241609, 'A', 'T', panel_obj.bed_file.path, 100, 10)
         self.assertTrue(variant1_check)
         
         #Incorrect format - position not in bed
-        variant2_check, error = variant_format_check(7, 1, 'A', 'T', panel_obj.bed_file.path, 100, 10)
+        variant2_check, error = variant_format_check('7', 1, 'A', 'T', panel_obj.bed_file.path, 100, 10)
         self.assertFalse(variant2_check)
         
         #Incorrect format - ref not a nucleotide
-        variant3_check, error = variant_format_check(7, 55241609, 'X', 'T', panel_obj.bed_file.path, 100, 10)
+        variant3_check, error = variant_format_check('7', 55241609, 'X', 'T', panel_obj.bed_file.path, 100, 10)
         self.assertFalse(variant3_check)
         
         #Incorrect format - alt not a nucleotide
-        variant4_check, error = variant_format_check(7, 55241609, 'A', 'delin', panel_obj.bed_file.path, 100, 10)
+        variant4_check, error = variant_format_check('7', 55241609, 'A', 'delin', panel_obj.bed_file.path, 100, 10)
         self.assertFalse(variant4_check)
         
         #Incorrect format - total reads 0
-        variant5_check, error = variant_format_check(7, 55241609, 'A', 'T', panel_obj.bed_file.path, 0, 10)
+        variant5_check, error = variant_format_check('7', 55241609, 'A', 'T', panel_obj.bed_file.path, 0, 10)
         self.assertFalse(variant5_check)
         
         #Incorrect format - alt reads 0
-        variant6_check, error = variant_format_check(7, 55241609, 'A', 'T', panel_obj.bed_file.path, 100, 0)
+        variant6_check, error = variant_format_check('7', 55241609, 'A', 'T', panel_obj.bed_file.path, 100, 0)
         self.assertFalse(variant6_check)
+
+        #Incorrect format - not a chromosome
+        variant7_check, error = variant_format_check('86', 55241609, 'A', 'T', panel_obj.bed_file.path, 100, 0)
+        self.assertFalse(variant7_check)
       
 class TestNTCCalls(TestCase):
     """

--- a/analysis/tests.py
+++ b/analysis/tests.py
@@ -1063,8 +1063,38 @@ class TestDna(TestCase):
         sample_data = get_sample_info(sample_obj)
 
         self.assertEqual(sample_data['is_myeloid_referral'], False)
-
-
+        
+    def test_variant_format_check(self):
+        """
+        Test utils function which checks format of manual variant entry
+        """
+        
+        panel_obj = Panel.objects.get(panel_name='Lung', assay='1', genome_build=37, live=True)
+        
+        #Correct format
+        variant1_check, error = variant_format_check(7, 55241609, 'A', 'T', panel_obj.bed_file.path, 100, 10)
+        self.assertTrue(variant1_check)
+        
+        #Incorrect format - position not in bed
+        variant2_check, error = variant_format_check(7, 1, 'A', 'T', panel_obj.bed_file.path, 100, 10)
+        self.assertFalse(variant2_check)
+        
+        #Incorrect format - ref not a nucleotide
+        variant3_check, error = variant_format_check(7, 55241609, 'X', 'T', panel_obj.bed_file.path, 100, 10)
+        self.assertFalse(variant3_check)
+        
+        #Incorrect format - alt not a nucleotide
+        variant4_check, error = variant_format_check(7, 55241609, 'A', 'delin', panel_obj.bed_file.path, 100, 10)
+        self.assertFalse(variant4_check)
+        
+        #Incorrect format - total reads 0
+        variant5_check, error = variant_format_check(7, 55241609, 'A', 'T', panel_obj.bed_file.path, 0, 10)
+        self.assertFalse(variant5_check)
+        
+        #Incorrect format - alt reads 0
+        variant6_check, error = variant_format_check(7, 55241609, 'A', 'T', panel_obj.bed_file.path, 100, 0)
+        self.assertFalse(variant6_check)
+      
 class TestNTCCalls(TestCase):
     """
     Load in DNA control sample with NTC contamination spiked in, test that 

--- a/analysis/utils.py
+++ b/analysis/utils.py
@@ -949,10 +949,26 @@ def if_nucleotide(string):
             
     return check
 
+def if_chrom(string):
+    """
+    Function to check if chromosome is 1-22 or X/Y
+    """
+    chroms = ["1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", "22", "X", "Y"]
+    if string in chroms:
+        return True
+    else:
+        return False
+
 def variant_format_check(chrm, position, ref, alt, panel_bed_path, total_reads, alt_reads):
     """
     Function to check if format of a manually entered variant is correct
     """
+
+    #Check the chromosome is sensible
+    chrm_check = if_chrom(chrm)
+    if not chrm_check:
+
+        return False, f'{chrm} is not a chromosome - please correct'
     
     #Check position is right genome build and panel
     #Get overlap with panel bed to check genome build (check below)

--- a/analysis/utils.py
+++ b/analysis/utils.py
@@ -968,7 +968,7 @@ def variant_format_check(chrm, position, ref, alt, panel_bed_path, total_reads, 
     chrm_check = if_chrom(chrm)
     if not chrm_check:
 
-        return False, f'{chrm} is not a chromosome - please correct'
+        return False, f'{chrm} is not a chromosome - please correct. Do not include "chr" in this box.'
     
     #Check position is right genome build and panel
     #Get overlap with panel bed to check genome build (check below)

--- a/analysis/utils.py
+++ b/analysis/utils.py
@@ -4,6 +4,7 @@ from .forms import NewVariantForm, SubmitForm, VariantCommentForm, FusionComment
 from django.utils import timezone
 from django.db import transaction
 
+import pybedtools
 
 def get_samples(samples):
     """
@@ -504,7 +505,6 @@ def get_variant_info(sample_data, sample_obj):
 def get_fusion_info(sample_data, sample_obj):
     """
     Get information on all fusions in a sample analysis to generate the fusion portion of the context dictionary
-
     """
 
     fusions = FusionPanelAnalysis.objects.filter(sample_analysis=sample_obj)
@@ -935,3 +935,55 @@ def get_poly_list(poly_list_obj, user):
             checking_list.append(formatted_variant)
 
     return confirmed_list, checking_list
+    
+def if_nucleotide(string):
+    """
+    Function to check if nucleotide is a string
+    """
+    check = True
+    for char in string:
+    
+        if char not in 'ATCGN':
+        
+            check = False
+            
+    return check
+
+def variant_format_check(chrm, position, ref, alt, panel_bed_path, total_reads, alt_reads):
+    """
+    Function to check if format of a manually entered variant is correct
+    """
+    
+    #Check position is right genome build and panel
+    #Get overlap with panel bed to check genome build (check below)
+    panel_bed_file = panel_bed_path
+    panel_bed = pybedtools.BedTool(panel_bed_file)
+    variant_as_bed=f"{chrm}\t{int(position)-1}\t{position}"
+    variant_bed_region = pybedtools.BedTool(variant_as_bed, from_string=True)
+    overlaps_panel = len(panel_bed.intersect(variant_bed_region)) > 0
+    
+    #If the coordinates are in the wrong genome build - check they overlap with bed (calculated above)
+    if overlaps_panel == 0:
+            
+        return False, 'Genomic coordinates given are not on the panel - Have you used coordinates for the correct genome build?'
+                
+    #Check ref/alt format (check below)
+    ref_check = if_nucleotide(ref)
+    alt_check = if_nucleotide(alt)
+    
+    #Error out if the REF or ALT has non NGS characters (calculated above)
+    if not ref_check or not alt_check:
+                
+        return False, 'Ref or Alt nucleotide is not A,T,C or G - please correct'
+                
+    #Error out if total depth is set to zero
+    if total_reads == 0:
+                      	
+        return False, 'Total read counts can not be zero'
+                
+    #Error out if alt read depth is set to zero
+    if alt_reads == 0:
+                
+        return False, 'Alt read counts can not be zero'
+
+    return True, ''

--- a/analysis/views.py
+++ b/analysis/views.py
@@ -554,31 +554,37 @@ def analysis_sheet(request, sample_id):
 
 
         # if add new variant form is clicked
-        if 'hgvs_g' in request.POST:
+        if 'chrm' in request.POST:
             new_variant_form = NewVariantForm(request.POST)
 
             if new_variant_form.is_valid():
 
                 new_variant_data = new_variant_form.cleaned_data
-		
-		#Split out the variant into it's component parts so we can check formatting and error if not correct
-                try:
-                    chromosome = new_variant_data['hgvs_g'].split(":")[0]
-                    position = re.findall('\d+', new_variant_data['hgvs_g'].split(':')[1])[0]
-                    ref = re.sub('[0-9]', '', new_variant_data['hgvs_g'].split(':')[1].split('>')[0]) 
-                    alt = re.sub('[0-9]', '', new_variant_data['hgvs_g'].split(':')[1].split('>')[1])
-                    variant_check = True
-                
-                except:
-                
-                    variant_check = False
+
+                #Get variant together from components
+                new_variant = f"{new_variant_data['chrm']}:{new_variant_data['position']}{new_variant_data['ref'].upper()}>{new_variant_data['alt'].upper()}"
                     
                 #Get overlap with panel bed to check genome build (check below)
                 panel_bed_file = sample_obj.panel.bed_file.path
                 panel_bed = pybedtools.BedTool(panel_bed_file)
-                variant_as_bed=f"{chromosome}\t{int(position)-1}\t{position}"
+                variant_as_bed=f"{new_variant_data['chrm']}\t{int(new_variant_data['position'])-1}\t{new_variant_data['position']}"
                 variant_bed_region = pybedtools.BedTool(variant_as_bed, from_string=True)
                 overlaps_panel = len(panel_bed.intersect(variant_bed_region)) > 0
+                
+                #Check ref/alt format (check below)
+                ref_check = True
+                for i in new_variant_data['ref']:
+                
+                	if i not in 'ATCGN':
+                	
+                		ref_check = False
+                		
+                alt_check = True
+                for i in new_variant_data['alt']:
+                
+                	if i not in 'ATCGN':
+                	
+                		alt_check = False
                 
                 #FORMATTING CHECKS
                 #Error out if total depth is set to zero
@@ -591,31 +597,21 @@ def analysis_sheet(request, sample_id):
                 
                     context['warning'].append('Alt read counts can not be zero')
                      
-                #Error out if the variant format is not correct (based on try except above)
-                elif not variant_check:
+                #Error out if the REF or ALT has non NGS characters (calculated above)
+                elif not ref_check or not alt_check:
                 
-                    context['warning'].append('Genomic coordinates are not in the correct format, ensure it contains CHROMOSOME : POSITION REF > ALT')
-                	
-                #Error if ref or alt are missing
-                elif ref == "" or alt == "":
-                
-                    context['warning'].append('Genomic coordinates are not in the correct format, ensure it contains CHROMOSOME : POSITION REF > ALT')
-                
-                #If the chr or position contain the letters chr or g	
-                elif "chr" in chromosome or "g" in chromosome:
-                
-                    context['warning'].append('Genomic coordinates are not in the correct format, ensure it contains CHROMOSOME : POSITION REF > ALT. Do not include chr for the chromosome or g. anywhere.')	
+                    context['warning'].append('Ref or Alt nucleotide is not A,T,C or G - please correct')
                     
                 #If the coordinates are in the wrong genome build - check they overlap with bed (calculated above)
                 elif overlaps_panel == 0:
                 
-                    context['warning'].append('Genomic coordinates given are not on panel - Have you used coordinates for the correct genome build?')     
+                    context['warning'].append('Genomic coordinates given are not on the panel - Have you used coordinates for the correct genome build?')     
                                     
                 else:
                 
                     #Lock to same genome build as sample_analysis 
                     new_variant_object, created = Variant.objects.get_or_create(
-                        variant = new_variant_data['hgvs_g'],
+                        variant = new_variant,
                         genome_build = sample_obj.genome_build,
 
                     )


### PR DESCRIPTION
Fix which closes #75 and closes #81 

Note - I've branched off of home_page due to the static differences in development. I can't make a PR to development as it just crashes!! Not sure if it's best to merge to home_page or wait until that PR is done and change this to merge with development.

Changes:
- Changed form for manual entry of SNV to break up the HGVSg into chromosome, position, ref and alt. Chromosome and position can only be an integer and won't let you type letters into the box. 
- Checks in place within a function in utils. Checks that ref and alt are correct letters and that the position is within the regions on the panel bed as well as the existing checks on read counts not being 0. Hopefully will reduce incorrect formatted entries and entries in the wrong genome build.
- Added unit tests for this function. 
- Added manual tag to report html page and to PDF.  
- Removed double % issue on PDF report.

Unit tests all run correctly. Manually checked both correct and incorrectly formatted variants. Manually checked PDF report format.