### PR TITLE
Order the fusion check objects

### DIFF
--- a/analysis/utils.py
+++ b/analysis/utils.py
@@ -511,7 +511,7 @@ def get_fusion_info(sample_data, sample_obj):
     for fusion_object in fusions:
 
         # get checks for each variant
-        fusion_checks = FusionCheck.objects.filter(fusion_analysis=fusion_object)
+        fusion_checks = FusionCheck.objects.filter(fusion_analysis=fusion_object).order_by('pk')
         fusion_checks_list = [ v.get_decision_display() for v in fusion_checks ]
         latest_check = fusion_checks.latest('pk')
 


### PR DESCRIPTION
Hotfix for a bug where a case couldnt be finalised because the last two checks didnt agree, but they did. It was becuase the checks were in the wrong order. 

Added `.order_by('pk')` to the end of the query to match the SNV code here - https://github.com/AWGL/somatic_db/blob/e0f39592e59a78bf83cadb71542d3af69f0e42de/analysis/utils.py#L340