### PR TITLE
LMS XML updates

### DIFF
--- a/analysis/models.py
+++ b/analysis/models.py
@@ -114,6 +114,7 @@ class Panel(models.Model):
     manual_review_required = models.BooleanField(default=False)
     manual_review_desc = models.CharField(max_length=200, blank=True, null=True) # pipe seperated, no spaces
     bed_file = models.FileField(upload_to=make_bedfile_path, blank=True, null=True)
+    report_snv_vaf = models.BooleanField(default=False)
 
     # fusion settings
     show_fusions = models.BooleanField()

--- a/analysis/templates/analysis/analysis-depth.html
+++ b/analysis/templates/analysis/analysis-depth.html
@@ -195,7 +195,7 @@
                     <tbody>
                     {% for gap in value.gaps_135 %}
                       <tr>
-                        <td>{{ gap.hgvs_c }}</td>
+                        <td>{{ gap.gene }} {{ gap.hgvs_c }}</td>
                         <td>
                           {{ gap.genomic }}
                           {% if sample_data.genome_build == 37 %}
@@ -233,7 +233,7 @@
                     <tbody>
                     {% for gap in value.gaps_270 %}
                       <tr>
-                        <td>{{ gap.hgvs_c }}</td>
+                        <td>{{ gap.gene }} {{ gap.hgvs_c }}</td>
                         <td>
                           {{ gap.genomic }}
                           {% if sample_data.genome_build == 37 %}
@@ -304,7 +304,7 @@
                     <tbody>
                     {% for gap in value.gaps_1000 %}
                       <tr>
-                        <td>{{ gap.hgvs_c }}</td>
+                        <td>{{ gap.gene }} {{ gap.hgvs_c }}</td>
                         <td>
                           {{ gap.genomic }}
                           {% if sample_data.genome_build == 37 %}

--- a/analysis/templates/analysis/analysis-depth.html
+++ b/analysis/templates/analysis/analysis-depth.html
@@ -265,19 +265,23 @@
                         <th scope="col" class="col-5">HGVS</th>
                         <th scope="col" class="col-5">Genomic</th>
                         <th scope="col" class="col-2">% COSMIC</th>
+                        <th scope="col" class="col-1">Counts COSMIC</th>
                       </tr>
                     </thead>
                     <tbody>
-                    {% for r in value.gaps_500 %}
+                    {% for gap in value.gaps_500 %}
                       <tr>
-                        <td>{{ r.hgvs_c }}</td>
-                        <td>{{ r.genomic }}</td>
-                        <!-- only show cosmic % when not none -->
-                        {% if r.percent_cosmic %}
-                          <td>{{ r.percent_cosmic }}%</td>
-                        {% else %}
-                          <td>N/A</td>
-                        {% endif %}
+                        <td>{{ gap.gene }} {{ gap.hgvs_c }}</td>
+                        <td>
+                          {{ gap.genomic }}
+                          {% if sample_data.genome_build == 37 %}
+                          <span class = "badge badge-info badge-pill">GRCh{{ sample_data.genome_build }}</span>
+                          {% elif sample_data.genome_build == 38 %}
+                          <span class = "badge badge-success badge-pill">GRCh{{ sample_data.genome_build }}</span>
+                          {% endif %}
+                        </td>
+                        <td>{{ gap.percent_cosmic }}</td>
+                        <td>{{ gap.counts_cosmic }}</td>
                       </tr>
                     {% endfor %}
                     </tbody>
@@ -299,6 +303,7 @@
                         <th scope="col" class="col-5">HGVS</th>
                         <th scope="col" class="col-5">Genomic</th>
                         <th scope="col" class="col-2">% COSMIC</th>
+                        <th scope="col" class="col-1">Counts COSMIC</th>
                       </tr>
                     </thead>
                     <tbody>

--- a/analysis/templates/analysis/analysis-report.html
+++ b/analysis/templates/analysis/analysis-report.html
@@ -59,6 +59,7 @@
 <!-- SNV section - variant calls -->
 {% if sample_data.panel_obj.show_snvs %}
 <h4>SNVs & indels - variant calls</h4>
+<small class="form-text text-muted">Only genuine variants are displayed here, see 'SNVs & indels' tab for all calls</small>
 <table class="table table-sm table-striped table-hover">
   <thead>
     <tr>
@@ -77,7 +78,7 @@
     {% if variant_data.no_calls %}
       <tr><td colspan="7">No calls</td></tr>
 
-    <!-- otherwise list all genuine or miscalled variants -->
+    <!-- otherwise list all genuine variants -->
     {% else%}
       {% for v in variant_data.variant_calls %}
         {% if v.final_decision == "Genuine" %}
@@ -349,6 +350,7 @@
 <!-- fusions section -->
 {% if sample_data.panel_obj.show_fusions %}
 <h4>Fusions</h4>
+<small class="form-text text-muted">Only genuine fusions are displayed here, see 'Fusions' tab for all calls</small>
 <table class="table table-sm table-striped table-hover">
   <thead>
     <tr>

--- a/analysis/templates/analysis/analysis-report.html
+++ b/analysis/templates/analysis/analysis-report.html
@@ -229,7 +229,7 @@
             {% if values.gaps_135 %}
               {% for gap in values.gaps_135 %}
               <tr>
-                <td>{{ gap.hgvs_c }}</td>
+                <td>{{ gap.gene }} {{ gap.hgvs_c }}</td>
                 <td>{{ gap.percent_cosmic }}</td>
                 <td>{{ gap.counts_cosmic }}</td>
               </tr>
@@ -261,7 +261,7 @@
             {% if values.gaps_270 %}
               {% for gap in values.gaps_270 %}
               <tr>
-                <td>{{ gap.hgvs_c }}</td>
+                <td>{{ gap.gene }} {{ gap.hgvs_c }}</td>
                 <td>{{ gap.percent_cosmic }}</td>
                 <td>{{ gap.counts_cosmic }}</td>
               </tr>
@@ -293,7 +293,7 @@
             {% if values.gaps_500 %}
               {% for gap in values.gaps_500 %}
               <tr>
-                <td>{{ gap.hgvs_c }}</td>
+                <td>{{ gap.gene }} {{ gap.hgvs_c }}</td>
                 <td>{{ gap.percent_cosmic }}</td>
                 <td>{{ gap.counts_cosmic }}</td>
               </tr>
@@ -325,7 +325,7 @@
             {% if values.gaps_1000 %}
               {% for gap in values.gaps_1000 %}
               <tr>
-                <td>{{ gap.hgvs_c }}</td>
+                <td>{{ gap.gene }} {{ gap.hgvs_c }}</td>
                 <td>{{ gap.percent_cosmic }}</td>
                 <td>{{ gap.counts_cosmic }}</td>
               </tr>

--- a/analysis/templates/analysis/analysis-report.html
+++ b/analysis/templates/analysis/analysis-report.html
@@ -80,7 +80,7 @@
     <!-- otherwise list all genuine or miscalled variants -->
     {% else%}
       {% for v in variant_data.variant_calls %}
-        {% if v.final_decision == "Genuine" or v.final_decision == "Miscalled" %}
+        {% if v.final_decision == "Genuine" %}
         <tr>
           <td class="variant-pk" style="display:none">{{ v.pk }}</td>
           <td><p style="display:inline" id="igv">{{ v.genomic }} 
@@ -368,7 +368,7 @@
     <tr><td colspan="7">No calls</td></tr>
   {% else %}
     {% for v in fusion_data.fusion_calls %}
-    {% if v.final_decision == "Genuine" or v.final_decision == "Miscalled" %}
+    {% if v.final_decision == "Genuine" %}
     <tr>
       <td>{{ v.fusion_genes }}</td>
       <td>{{ v.fusion_hgvs }}</td>

--- a/analysis/templates/analysis/download_report.html
+++ b/analysis/templates/analysis/download_report.html
@@ -74,6 +74,7 @@
   <!-- SNV section - variant calls ------------------------------>
   {% if sample_data.panel_obj.show_snvs %}
   <h2>SNVs & indels - variant calls</h2>
+  <small class="form-text text-muted">Only genuine variants are displayed here, any miscalled or failed calls are listed at the end of this report</small>
 
   <table>
     <thead>
@@ -121,7 +122,6 @@
     {% endif %}
     </tbody>
   </table>
-  <small class="form-text text-muted">Only genuine variants are displayed here, any miscalled or failed calls are listed at the end of this report</small>
   <br>
   <br>
 
@@ -322,6 +322,8 @@
 
   {% if sample_data.panel_obj.show_fusions %}
   <h2>Fusions</h2>
+  <small class="form-text text-muted">Only genuine fusions are displayed here, any miscalled or failed calls are listed at the end of this report</small>
+
   <table>
     <thead>
       <tr>
@@ -369,7 +371,6 @@
     {% endif %}
     </tbody>
   </table>
-  <small class="form-text text-muted">Only genuine fusions are displayed here, any miscalled or failed calls are listed at the end of this report</small>
   <br>
   <br>
 

--- a/analysis/templates/analysis/download_report.html
+++ b/analysis/templates/analysis/download_report.html
@@ -91,10 +91,10 @@
     {% if variant_data.no_calls %}
       <tr><td colspan="7">No calls</td></tr>
 
-    <!-- otherwise list all genuine or miscalled variants -->
+    <!-- otherwise list all genuine variants -->
     {% else%}
       {% for v in variant_data.variant_calls %}
-        {% if v.final_decision == "Genuine" or v.final_decision == "Miscalled" %}
+        {% if v.final_decision == "Genuine" %}
         <tr>
           <td>{{ v.genomic | truncatechars:20 }}
           {% if v.manual_upload %}
@@ -121,6 +121,7 @@
     {% endif %}
     </tbody>
   </table>
+  <small class="form-text text-muted">Only genuine variants are displayed here, any miscalled or failed calls are listed at the end of this report</small>
   <br>
   <br>
 
@@ -336,10 +337,13 @@
 
     <tbody>
     {% if fusion_data.no_calls %}
-      <tr><td colspan="6">No calls</td></tr>
+      {% if sample_data.panel_obj.show_fusion_vaf %}<tr><td colspan="7">No calls</td></tr>
+      {% else %}<tr><td colspan="6">No calls</td></tr>
+      {% endif %}
+
     {% else %}
       {% for v in fusion_data.fusion_calls %}
-      {% if v.final_decision == "Genuine" or v.final_decision == "Miscalled" %}
+      {% if v.final_decision == "Genuine" %}
       <tr>
         <td>{{ v.fusion_genes }}</td>
         <td>{{ v.fusion_supporting_reads }}</td>
@@ -365,6 +369,7 @@
     {% endif %}
     </tbody>
   </table>
+  <small class="form-text text-muted">Only genuine fusions are displayed here, any miscalled or failed calls are listed at the end of this report</small>
   <br>
   <br>
 
@@ -432,6 +437,29 @@
   <br>
   
   <!-- footer -->
+  <!-- list any miscalled or failed variants -->
+  {% if sample_data.panel_obj.show_snvs %}
+  <p class="form-text text-muted">Miscalled or failed SNV/indels, please refer back to the SVD to see more detail: 
+  {% for v in variant_data.variant_calls %}
+    {% if v.final_decision == "Miscalled" or v.final_decision == "Failed call" %}
+    {{ v.gene }} {{ v.hgvs_c }}, 
+    {% endif %}
+  {% endfor %}
+  </p>
+  {% endif %}
+
+  <!-- list any miscalled or failed fusions -->
+  {% if sample_data.panel_obj.show_fusions %}
+  <p class="form-text text-muted">Miscalled or failed fusions, please refer back to the SVD to see more detail: 
+  {% for v in fusion_data.fusion_calls %}
+    {% if v.final_decision == "Miscalled" or v.final_decision == "Failed call" %}
+      {{ v.fusion_genes }}, 
+    {% endif %}
+  {% endfor %}
+  </p>
+  {% endif %}
+
+  <!-- audit trail -->
   <p>View report in somatic variant database: <a href="http://10.59.210.247:8000/analysis/{{ sample_data.sample_pk }}#report" target="_blank">http://10.59.210.247:8000/analysis/{{ sample_data.sample_pk }}#report</a></p>
   <p>PDF report generated {% now "jS F Y H:i" %}</p>
 

--- a/analysis/templates/analysis/download_report.html
+++ b/analysis/templates/analysis/download_report.html
@@ -440,24 +440,12 @@
   <!-- footer -->
   <!-- list any miscalled or failed variants -->
   {% if sample_data.panel_obj.show_snvs %}
-  <p class="form-text text-muted">Miscalled or failed SNV/indels, please refer back to the SVD to see more detail: 
-  {% for v in variant_data.variant_calls %}
-    {% if v.final_decision == "Miscalled" or v.final_decision == "Failed call" %}
-    {{ v.gene }} {{ v.hgvs_c }}, 
-    {% endif %}
-  {% endfor %}
-  </p>
+  <p class="form-text text-muted">Miscalled or failed SNV/indels, please refer back to the SVD to see more detail: {{ variant_data.other_calls_text }}</p>
   {% endif %}
 
   <!-- list any miscalled or failed fusions -->
   {% if sample_data.panel_obj.show_fusions %}
-  <p class="form-text text-muted">Miscalled or failed fusions, please refer back to the SVD to see more detail: 
-  {% for v in fusion_data.fusion_calls %}
-    {% if v.final_decision == "Miscalled" or v.final_decision == "Failed call" %}
-      {{ v.fusion_genes }}, 
-    {% endif %}
-  {% endfor %}
-  </p>
+  <p class="form-text text-muted">Miscalled or failed fusions, please refer back to the SVD to see more detail: {{ fusion_data.other_calls_text }}</p>
   {% endif %}
 
   <!-- audit trail -->

--- a/analysis/templates/analysis/lims_xml.xml
+++ b/analysis/templates/analysis/lims_xml.xml
@@ -14,7 +14,7 @@
 
         <small_variants>
             {% for v in variant_data.variant_calls %}
-            {% if v.final_decision == "Genuine" or v.final_decision == "Miscalled" %}
+            {% if v.final_decision == "Genuine" %}
             <variant>
                 <variant_ID>{{ v.genomic }}</variant_ID>
                 <gene>{{ v.gene }}</gene>
@@ -36,7 +36,7 @@
 
         <structural_variants>
             {% for v in fusion_data.fusion_calls %}
-            {% if v.final_decision == "Genuine" or v.final_decision == "Miscalled" %}
+            {% if v.final_decision == "Genuine" %}
             <variant>
                 <genes>{{ v.fusion_genes }}</genes>
                 <hgvs>{{ v.fusion_hgvs }}</hgvs>

--- a/analysis/templates/analysis/lims_xml.xml
+++ b/analysis/templates/analysis/lims_xml.xml
@@ -23,10 +23,14 @@
                 <hgvs_p>{{ v.hgvs_p_short }}</hgvs_p>
                 <exon>{{ v.exon }}</exon>
                 <genome_build>{{ sample_data.genome_build }}</genome_build>
-                {% if sample_data.panel_obj.assay == '3' %}  {# VAF rounded to 2dp for ctDNA, whole number for the rest #}
-                <vaf>{{ v.vaf.vaf }}</vaf>
+                {% if sample_data.panel_obj.report_snv_vaf %}
+                    {% if sample_data.panel_obj.assay == '3' %}  {# VAF rounded to 2dp for ctDNA, whole number for the rest #}
+                    <vaf>{{ v.vaf.vaf }}</vaf>
+                    {% else %}
+                    <vaf>{{ v.vaf.vaf_rounded }}</vaf>
+                    {% endif %}
                 {% else %}
-                <vaf>{{ v.vaf.vaf_rounded }}</vaf>
+                <vaf></vaf>
                 {% endif %}
                 <igv_outcome>{{ v.final_decision }}</igv_outcome>
             </variant>

--- a/analysis/templates/analysis/lims_xml.xml
+++ b/analysis/templates/analysis/lims_xml.xml
@@ -66,6 +66,7 @@
                 {% for gene, values in coverage_data.regions.items %}
                 {% for gap in values.gaps_135 %}
                 <gap>
+                    <gene>{{ gap.gene }}</gene>
                     <region_name>{{ gap.hgvs_c }}</region_name>
                     <cosmic>{{ gap.percent_cosmic }}</cosmic>
                 </gap>
@@ -76,6 +77,7 @@
                 {% for gene, values in coverage_data.regions.items %}
                 {% for gap in values.gaps_270 %}
                 <gap>
+                    <gene>{{ gap.gene }}</gene>
                     <region_name>{{ gap.hgvs_c }}</region_name>
                     <cosmic>{{ gap.percent_cosmic }}</cosmic>
                 </gap>
@@ -86,6 +88,7 @@
                 {% for gene, values in coverage_data.regions.items %}
                 {% for gap in values.gaps_500 %}
                 <gap>
+                    <gene>{{ gap.gene }}</gene>
                     <region_name>{{ gap.hgvs_c }}</region_name>
                     <cosmic>{{ gap.percent_cosmic }}</cosmic>
                 </gap>
@@ -96,6 +99,7 @@
                 {% for gene, values in coverage_data.regions.items %}
                 {% for gap in values.gaps_1000 %}
                 <gap>
+                    <gene>{{ gap.gene }}</gene>
                     <region_name>{{ gap.hgvs_c }}</region_name>
                     <cosmic>{{ gap.percent_cosmic }}</cosmic>
                 </gap>

--- a/analysis/test_data/Database_38/sample17_endometrial-pole_coverage.json
+++ b/analysis/test_data/Database_38/sample17_endometrial-pole_coverage.json
@@ -201,7 +201,7 @@
                 "chr": 12,
                 "pos_start": 132673602,
                 "pos_end": 132673603,
-                "hgvs_c": "POLE(NM_006231.4)c.1331_1331",
+                "hgvs_c": "POLE(NM_006231.4):c.1331_1331",
                 "gene": "POLE",
                 "counts_cosmic": NaN,
                 "percent_cosmic": NaN
@@ -210,7 +210,7 @@
                 "chr": 12,
                 "pos_start": 132673626,
                 "pos_end": 132673627,
-                "hgvs_c": "POLE(NM_006231.4)c.1307_1307",
+                "hgvs_c": "POLE(NM_006231.4):c.1307_1307",
                 "gene": "POLE",
                 "counts_cosmic": NaN,
                 "percent_cosmic": NaN
@@ -219,7 +219,7 @@
                 "chr": 12,
                 "pos_start": 132673663,
                 "pos_end": 132673664,
-                "hgvs_c": "POLE(NM_006231.4)c.1270_1270",
+                "hgvs_c": "POLE(NM_006231.4):c.1270_1270",
                 "gene": "POLE",
                 "counts_cosmic": NaN,
                 "percent_cosmic": NaN
@@ -228,7 +228,7 @@
                 "chr": 12,
                 "pos_start": 132673702,
                 "pos_end": 132673703,
-                "hgvs_c": "POLE(NM_006231.4)c.1231_1231",
+                "hgvs_c": "POLE(NM_006231.4):c.1231_1231",
                 "gene": "POLE",
                 "counts_cosmic": NaN,
                 "percent_cosmic": NaN
@@ -239,7 +239,7 @@
                 "chr": 12,
                 "pos_start": 132673260,
                 "pos_end": 132673261,
-                "hgvs_c": "POLE(NM_006231.4)c.1376_1376",
+                "hgvs_c": "POLE(NM_006231.4):c.1376_1376",
                 "gene": "POLE",
                 "counts_cosmic": NaN,
                 "percent_cosmic": NaN
@@ -248,7 +248,7 @@
                 "chr": 12,
                 "pos_start": 132673270,
                 "pos_end": 132673271,
-                "hgvs_c": "POLE(NM_006231.4)c.1366_1366",
+                "hgvs_c": "POLE(NM_006231.4):c.1366_1366",
                 "gene": "POLE",
                 "counts_cosmic": NaN,
                 "percent_cosmic": NaN
@@ -257,7 +257,7 @@
                 "chr": 12,
                 "pos_start": 132673602,
                 "pos_end": 132673603,
-                "hgvs_c": "POLE(NM_006231.4)c.1331_1331",
+                "hgvs_c": "POLE(NM_006231.4):c.1331_1331",
                 "gene": "POLE",
                 "counts_cosmic": NaN,
                 "percent_cosmic": NaN
@@ -266,7 +266,7 @@
                 "chr": 12,
                 "pos_start": 132673626,
                 "pos_end": 132673627,
-                "hgvs_c": "POLE(NM_006231.4)c.1307_1307",
+                "hgvs_c": "POLE(NM_006231.4):c.1307_1307",
                 "gene": "POLE",
                 "counts_cosmic": NaN,
                 "percent_cosmic": NaN
@@ -275,7 +275,7 @@
                 "chr": 12,
                 "pos_start": 132673663,
                 "pos_end": 132673664,
-                "hgvs_c": "POLE(NM_006231.4)c.1270_1270",
+                "hgvs_c": "POLE(NM_006231.4):c.1270_1270",
                 "gene": "POLE",
                 "counts_cosmic": NaN,
                 "percent_cosmic": NaN
@@ -284,7 +284,7 @@
                 "chr": 12,
                 "pos_start": 132673702,
                 "pos_end": 132673703,
-                "hgvs_c": "POLE(NM_006231.4)c.1231_1231",
+                "hgvs_c": "POLE(NM_006231.4):c.1231_1231",
                 "gene": "POLE",
                 "counts_cosmic": NaN,
                 "percent_cosmic": NaN
@@ -293,7 +293,7 @@
                 "chr": 12,
                 "pos_start": 132675738,
                 "pos_end": 132675739,
-                "hgvs_c": "POLE(NM_006231.4)c.1102_1102",
+                "hgvs_c": "POLE(NM_006231.4):c.1102_1102",
                 "gene": "POLE",
                 "counts_cosmic": NaN,
                 "percent_cosmic": NaN
@@ -302,7 +302,7 @@
                 "chr": 12,
                 "pos_start": 132675740,
                 "pos_end": 132675741,
-                "hgvs_c": "POLE(NM_006231.4)c.1100_1100",
+                "hgvs_c": "POLE(NM_006231.4):c.1100_1100",
                 "gene": "POLE",
                 "counts_cosmic": NaN,
                 "percent_cosmic": NaN
@@ -311,7 +311,7 @@
                 "chr": 12,
                 "pos_start": 132676564,
                 "pos_end": 132676565,
-                "hgvs_c": "POLE(NM_006231.4)c.890_890",
+                "hgvs_c": "POLE(NM_006231.4):c.890_890",
                 "gene": "POLE",
                 "counts_cosmic": NaN,
                 "percent_cosmic": NaN
@@ -320,7 +320,7 @@
                 "chr": 12,
                 "pos_start": 132676570,
                 "pos_end": 132676571,
-                "hgvs_c": "POLE(NM_006231.4)c.884_884",
+                "hgvs_c": "POLE(NM_006231.4):c.884_884",
                 "gene": "POLE",
                 "counts_cosmic": NaN,
                 "percent_cosmic": NaN
@@ -329,7 +329,7 @@
                 "chr": 12,
                 "pos_start": 132676597,
                 "pos_end": 132676598,
-                "hgvs_c": "POLE(NM_006231.4)c.857_857",
+                "hgvs_c": "POLE(NM_006231.4):c.857_857",
                 "gene": "POLE",
                 "counts_cosmic": NaN,
                 "percent_cosmic": NaN

--- a/analysis/test_data/Database_38/sample19_breast_coverage.json
+++ b/analysis/test_data/Database_38/sample19_breast_coverage.json
@@ -102,7 +102,7 @@
                 "chr": 3,
                 "pos_start": 179210180,
                 "pos_end": 179210203,
-                "hgvs_c": "PIK3CA(NM_006218.4)c.1252-5_1269",
+                "hgvs_c": "PIK3CA(NM_006218.4):c.1252-5_1269",
                 "gene": "PIK3CA",
                 "counts_cosmic": 144,
                 "percent_cosmic": 1.86
@@ -111,7 +111,7 @@
                 "chr": 3,
                 "pos_start": 179210191,
                 "pos_end": 179210194,
-                "hgvs_c": "PIK3CA(NM_006218.4)c.1258_1260",
+                "hgvs_c": "PIK3CA(NM_006218.4):c.1258_1260",
                 "gene": "PIK3CA",
                 "counts_cosmic": 115,
                 "percent_cosmic": 1.49
@@ -120,7 +120,7 @@
                 "chr": 3,
                 "pos_start": 179210327,
                 "pos_end": 179210343,
-                "hgvs_c": "PIK3CA(NM_006218.4)c.1394_1404+5",
+                "hgvs_c": "PIK3CA(NM_006218.4):c.1394_1404+5",
                 "gene": "PIK3CA",
                 "counts_cosmic": 0,
                 "percent_cosmic": 0.0
@@ -129,7 +129,7 @@
                 "chr": 3,
                 "pos_start": 179218204,
                 "pos_end": 179218209,
-                "hgvs_c": "PIK3CA(NM_006218.4)c.1540-5_1540-1",
+                "hgvs_c": "PIK3CA(NM_006218.4):c.1540-5_1540-1",
                 "gene": "PIK3CA",
                 "counts_cosmic": 0,
                 "percent_cosmic": 0.0
@@ -138,7 +138,7 @@
                 "chr": 3,
                 "pos_start": 179234088,
                 "pos_end": 179234092,
-                "hgvs_c": "PIK3CA(NM_006218.4)c.2937-5_2937-2",
+                "hgvs_c": "PIK3CA(NM_006218.4):c.2937-5_2937-2",
                 "gene": "PIK3CA",
                 "counts_cosmic": 0,
                 "percent_cosmic": 0.0

--- a/analysis/test_data/Database_38/sample20_melanoma_coverage.json
+++ b/analysis/test_data/Database_38/sample20_melanoma_coverage.json
@@ -136,7 +136,7 @@
                 "chr": 4,
                 "pos_start": 54729329,
                 "pos_end": 54729334,
-                "hgvs_c": "KIT(NM_000222.3)c.1991-5_1991-1",
+                "hgvs_c": "KIT(NM_000222.3):c.1991-5_1991-1",
                 "gene": "KIT",
                 "counts_cosmic": 0,
                 "percent_cosmic": 0.0
@@ -145,7 +145,7 @@
                 "chr": 4,
                 "pos_start": 54729453,
                 "pos_end": 54729456,
-                "hgvs_c": "KIT(NM_000222.3)c.2110_2112",
+                "hgvs_c": "KIT(NM_000222.3):c.2110_2112",
                 "gene": "KIT",
                 "counts_cosmic": 0,
                 "percent_cosmic": 0.0
@@ -154,7 +154,7 @@
                 "chr": 4,
                 "pos_start": 54729458,
                 "pos_end": 54729490,
-                "hgvs_c": "KIT(NM_000222.3)c.2115_2141+5",
+                "hgvs_c": "KIT(NM_000222.3):c.2115_2141+5",
                 "gene": "KIT",
                 "counts_cosmic": 1,
                 "percent_cosmic": 0.14
@@ -198,7 +198,7 @@
                 "chr": 7,
                 "pos_start": 140753387,
                 "pos_end": 140753398,
-                "hgvs_c": "BRAF(NM_004333.6)c.1742-5_1747",
+                "hgvs_c": "BRAF(NM_004333.6):c.1742-5_1747",
                 "gene": "BRAF",
                 "counts_cosmic": 12,
                 "percent_cosmic": 0.1

--- a/analysis/test_data/Database_38/sample21_colorectal_coverage.json
+++ b/analysis/test_data/Database_38/sample21_colorectal_coverage.json
@@ -69,7 +69,7 @@
                 "chr": 1,
                 "pos_start": 114709580,
                 "pos_end": 114709583,
-                "hgvs_c": "NRAS(NM_002524.5)c.436_438",
+                "hgvs_c": "NRAS(NM_002524.5):c.436_438",
                 "gene": "NRAS",
                 "counts_cosmic": 0,
                 "percent_cosmic": 0.0
@@ -78,7 +78,7 @@
                 "chr": 1,
                 "pos_start": 114709667,
                 "pos_end": 114709670,
-                "hgvs_c": "NRAS(NM_002524.5)c.349_351",
+                "hgvs_c": "NRAS(NM_002524.5):c.349_351",
                 "gene": "NRAS",
                 "counts_cosmic": 0,
                 "percent_cosmic": 0.0
@@ -87,7 +87,7 @@
                 "chr": 1,
                 "pos_start": 114713906,
                 "pos_end": 114713909,
-                "hgvs_c": "NRAS(NM_002524.5)c.181_183",
+                "hgvs_c": "NRAS(NM_002524.5):c.181_183",
                 "gene": "NRAS",
                 "counts_cosmic": 317,
                 "percent_cosmic": 49.22
@@ -96,7 +96,7 @@
                 "chr": 1,
                 "pos_start": 114713912,
                 "pos_end": 114713915,
-                "hgvs_c": "NRAS(NM_002524.5)c.175_177",
+                "hgvs_c": "NRAS(NM_002524.5):c.175_177",
                 "gene": "NRAS",
                 "counts_cosmic": 0,
                 "percent_cosmic": 0.0
@@ -140,7 +140,7 @@
                 "chr": 3,
                 "pos_start": 179218204,
                 "pos_end": 179218215,
-                "hgvs_c": "PIK3CA(NM_006218.4)c.1540-5_1545",
+                "hgvs_c": "PIK3CA(NM_006218.4):c.1540-5_1545",
                 "gene": "PIK3CA",
                 "counts_cosmic": 0,
                 "percent_cosmic": 0.0
@@ -149,7 +149,7 @@
                 "chr": 3,
                 "pos_start": 179218301,
                 "pos_end": 179218303,
-                "hgvs_c": "PIK3CA(NM_006218.4)c.1632_1633",
+                "hgvs_c": "PIK3CA(NM_006218.4):c.1632_1633",
                 "gene": "PIK3CA",
                 "counts_cosmic": 0,
                 "percent_cosmic": 0.0
@@ -158,7 +158,7 @@
                 "chr": 3,
                 "pos_start": 179218304,
                 "pos_end": 179218306,
-                "hgvs_c": "PIK3CA(NM_006218.4)c.1635_1636",
+                "hgvs_c": "PIK3CA(NM_006218.4):c.1635_1636",
                 "gene": "PIK3CA",
                 "counts_cosmic": 0,
                 "percent_cosmic": 0.0
@@ -167,7 +167,7 @@
                 "chr": 3,
                 "pos_start": 179218329,
                 "pos_end": 179218339,
-                "hgvs_c": "PIK3CA(NM_006218.4)c.1660_1664+5",
+                "hgvs_c": "PIK3CA(NM_006218.4):c.1660_1664+5",
                 "gene": "PIK3CA",
                 "counts_cosmic": 0,
                 "percent_cosmic": 0.0
@@ -176,7 +176,7 @@
                 "chr": 3,
                 "pos_start": 179234088,
                 "pos_end": 179234369,
-                "hgvs_c": "PIK3CA(NM_006218.4)c.2937-5_3207+5",
+                "hgvs_c": "PIK3CA(NM_006218.4):c.2937-5_3207+5",
                 "gene": "PIK3CA",
                 "counts_cosmic": 0,
                 "percent_cosmic": 0.0
@@ -241,7 +241,7 @@
                 "chr": 7,
                 "pos_start": 55191875,
                 "pos_end": 55191879,
-                "hgvs_c": "EGFR(NM_005228.5)c.2625+2_2625+5",
+                "hgvs_c": "EGFR(NM_005228.5):c.2625+2_2625+5",
                 "gene": "EGFR",
                 "counts_cosmic": 0,
                 "percent_cosmic": 0.0
@@ -252,7 +252,7 @@
                 "chr": 7,
                 "pos_start": 55173915,
                 "pos_end": 55174048,
-                "hgvs_c": "EGFR(NM_005228.5)c.2062-5_2184+5",
+                "hgvs_c": "EGFR(NM_005228.5):c.2062-5_2184+5",
                 "gene": "EGFR",
                 "counts_cosmic": 0,
                 "percent_cosmic": 0.0
@@ -261,7 +261,7 @@
                 "chr": 7,
                 "pos_start": 55174716,
                 "pos_end": 55174825,
-                "hgvs_c": "EGFR(NM_005228.5)c.2185-5_2283+5",
+                "hgvs_c": "EGFR(NM_005228.5):c.2185-5_2283+5",
                 "gene": "EGFR",
                 "counts_cosmic": 0,
                 "percent_cosmic": 0.0
@@ -270,7 +270,7 @@
                 "chr": 7,
                 "pos_start": 55181287,
                 "pos_end": 55181483,
-                "hgvs_c": "EGFR(NM_005228.5)c.2284-5_2469+5",
+                "hgvs_c": "EGFR(NM_005228.5):c.2284-5_2469+5",
                 "gene": "EGFR",
                 "counts_cosmic": 0,
                 "percent_cosmic": 0.0
@@ -279,7 +279,7 @@
                 "chr": 7,
                 "pos_start": 55191713,
                 "pos_end": 55191806,
-                "hgvs_c": "EGFR(NM_005228.5)c.2470-5_2557",
+                "hgvs_c": "EGFR(NM_005228.5):c.2470-5_2557",
                 "gene": "EGFR",
                 "counts_cosmic": 0,
                 "percent_cosmic": 0.0
@@ -288,7 +288,7 @@
                 "chr": 7,
                 "pos_start": 55191809,
                 "pos_end": 55191811,
-                "hgvs_c": "EGFR(NM_005228.5)c.2561_2562",
+                "hgvs_c": "EGFR(NM_005228.5):c.2561_2562",
                 "gene": "EGFR",
                 "counts_cosmic": 0,
                 "percent_cosmic": 0.0
@@ -297,7 +297,7 @@
                 "chr": 7,
                 "pos_start": 55191812,
                 "pos_end": 55191879,
-                "hgvs_c": "EGFR(NM_005228.5)c.2564_2625+5",
+                "hgvs_c": "EGFR(NM_005228.5):c.2564_2625+5",
                 "gene": "EGFR",
                 "counts_cosmic": 0,
                 "percent_cosmic": 0.0
@@ -340,7 +340,7 @@
                 "chr": 7,
                 "pos_start": 140753392,
                 "pos_end": 140753398,
-                "hgvs_c": "BRAF(NM_004333.6)c.1432+28178_1432+28183",
+                "hgvs_c": "BRAF(NM_004333.6):c.1432+28178_1432+28183",
                 "gene": "BRAF",
                 "counts_cosmic": 15,
                 "percent_cosmic": 0.13
@@ -351,7 +351,7 @@
                 "chr": 7,
                 "pos_start": 140753269,
                 "pos_end": 140753288,
-                "hgvs_c": "BRAF(NM_004333.6)c.1847_1860+5",
+                "hgvs_c": "BRAF(NM_004333.6):c.1847_1860+5",
                 "gene": "BRAF",
                 "counts_cosmic": 0,
                 "percent_cosmic": 0.0
@@ -360,7 +360,7 @@
                 "chr": 7,
                 "pos_start": 140753360,
                 "pos_end": 140753398,
-                "hgvs_c": "BRAF(NM_004333.6)c.1742-5_1774",
+                "hgvs_c": "BRAF(NM_004333.6):c.1742-5_1774",
                 "gene": "BRAF",
                 "counts_cosmic": 23,
                 "percent_cosmic": 0.19
@@ -369,7 +369,7 @@
                 "chr": 7,
                 "pos_start": 140781570,
                 "pos_end": 140781583,
-                "hgvs_c": "BRAF(NM_004333.6)c.1425_1432+5",
+                "hgvs_c": "BRAF(NM_004333.6):c.1425_1432+5",
                 "gene": "BRAF",
                 "counts_cosmic": 1,
                 "percent_cosmic": 0.01
@@ -378,7 +378,7 @@
                 "chr": 7,
                 "pos_start": 140781687,
                 "pos_end": 140781698,
-                "hgvs_c": "BRAF(NM_004333.6)c.1315-5_1320",
+                "hgvs_c": "BRAF(NM_004333.6):c.1315-5_1320",
                 "gene": "BRAF",
                 "counts_cosmic": 0,
                 "percent_cosmic": 0.0
@@ -455,7 +455,7 @@
                 "chr": 12,
                 "pos_start": 25225625,
                 "pos_end": 25225628,
-                "hgvs_c": "KRAS(NM_004985.5)c.436_438",
+                "hgvs_c": "KRAS(NM_004985.5):c.436_438",
                 "gene": "KRAS",
                 "counts_cosmic": 282,
                 "percent_cosmic": 1.06
@@ -464,7 +464,7 @@
                 "chr": 12,
                 "pos_start": 25225712,
                 "pos_end": 25225715,
-                "hgvs_c": "KRAS(NM_004985.5)c.349_351",
+                "hgvs_c": "KRAS(NM_004985.5):c.349_351",
                 "gene": "KRAS",
                 "counts_cosmic": 48,
                 "percent_cosmic": 0.18
@@ -473,7 +473,7 @@
                 "chr": 12,
                 "pos_start": 25227340,
                 "pos_end": 25227343,
-                "hgvs_c": "KRAS(NM_004985.5)c.181_183",
+                "hgvs_c": "KRAS(NM_004985.5):c.181_183",
                 "gene": "KRAS",
                 "counts_cosmic": 316,
                 "percent_cosmic": 1.19
@@ -482,7 +482,7 @@
                 "chr": 12,
                 "pos_start": 25227346,
                 "pos_end": 25227349,
-                "hgvs_c": "KRAS(NM_004985.5)c.175_177",
+                "hgvs_c": "KRAS(NM_004985.5):c.175_177",
                 "gene": "KRAS",
                 "counts_cosmic": 30,
                 "percent_cosmic": 0.11

--- a/analysis/test_data/Database_38/sample22_lung_coverage.json
+++ b/analysis/test_data/Database_38/sample22_lung_coverage.json
@@ -57,7 +57,7 @@
                 "chr": 7,
                 "pos_start": 55174773,
                 "pos_end": 55174779,
-                "hgvs_c": "EGFR(NM_005228.5)c.2237_2242",
+                "hgvs_c": "EGFR(NM_005228.5):c.2237_2242",
                 "gene": "EGFR",
                 "counts_cosmic": 69,
                 "percent_cosmic": 0.34
@@ -68,7 +68,7 @@
                 "chr": 7,
                 "pos_start": 55174772,
                 "pos_end": 55174787,
-                "hgvs_c": "EGFR(NM_005228.5)c.2236_2250",
+                "hgvs_c": "EGFR(NM_005228.5):c.2236_2250",
                 "gene": "EGFR",
                 "counts_cosmic": 928,
                 "percent_cosmic": 4.57
@@ -111,7 +111,7 @@
                 "chr": 7,
                 "pos_start": 140753393,
                 "pos_end": 140753398,
-                "hgvs_c": "BRAF(NM_004333.6)c.1742-5_1742-1",
+                "hgvs_c": "BRAF(NM_004333.6):c.1742-5_1742-1",
                 "gene": "BRAF",
                 "counts_cosmic": 0,
                 "percent_cosmic": 0.0
@@ -122,7 +122,7 @@
                 "chr": 7,
                 "pos_start": 140753269,
                 "pos_end": 140753276,
-                "hgvs_c": "BRAF(NM_004333.6)c.1859_1860+5",
+                "hgvs_c": "BRAF(NM_004333.6):c.1859_1860+5",
                 "gene": "BRAF",
                 "counts_cosmic": 0,
                 "percent_cosmic": 0.0
@@ -131,7 +131,7 @@
                 "chr": 7,
                 "pos_start": 140753365,
                 "pos_end": 140753398,
-                "hgvs_c": "BRAF(NM_004333.6)c.1742-5_1769",
+                "hgvs_c": "BRAF(NM_004333.6):c.1742-5_1769",
                 "gene": "BRAF",
                 "counts_cosmic": 0,
                 "percent_cosmic": 0.0
@@ -140,7 +140,7 @@
                 "chr": 7,
                 "pos_start": 140781570,
                 "pos_end": 140781581,
-                "hgvs_c": "BRAF(NM_004333.6)c.1427_1432+5",
+                "hgvs_c": "BRAF(NM_004333.6):c.1427_1432+5",
                 "gene": "BRAF",
                 "counts_cosmic": 0,
                 "percent_cosmic": 0.0
@@ -149,7 +149,7 @@
                 "chr": 7,
                 "pos_start": 140781690,
                 "pos_end": 140781698,
-                "hgvs_c": "BRAF(NM_004333.6)c.1315-5_1317",
+                "hgvs_c": "BRAF(NM_004333.6):c.1315-5_1317",
                 "gene": "BRAF",
                 "counts_cosmic": 0,
                 "percent_cosmic": 0.0
@@ -226,7 +226,7 @@
                 "chr": 12,
                 "pos_start": 25225625,
                 "pos_end": 25225628,
-                "hgvs_c": "KRAS(NM_004985.5)c.436_438",
+                "hgvs_c": "KRAS(NM_004985.5):c.436_438",
                 "gene": "KRAS",
                 "counts_cosmic": 0,
                 "percent_cosmic": 0.0
@@ -235,7 +235,7 @@
                 "chr": 12,
                 "pos_start": 25225712,
                 "pos_end": 25225715,
-                "hgvs_c": "KRAS(NM_004985.5)c.349_351",
+                "hgvs_c": "KRAS(NM_004985.5):c.349_351",
                 "gene": "KRAS",
                 "counts_cosmic": 0,
                 "percent_cosmic": 0.0

--- a/analysis/test_data/Database_38/sample3_aitcl_coverage.json
+++ b/analysis/test_data/Database_38/sample3_aitcl_coverage.json
@@ -480,7 +480,7 @@
                 "chr": 15,
                 "pos_start": 90088604,
                 "pos_end": 90088607,
-                "hgvs_c": "IDH2(NM_002168.4)c.514_516",
+                "hgvs_c": "IDH2(NM_002168.4):c.514_516",
                 "gene": "IDH2",
                 "counts_cosmic": NaN,
                 "percent_cosmic": NaN
@@ -491,7 +491,7 @@
                 "chr": 15,
                 "pos_start": 90088604,
                 "pos_end": 90088607,
-                "hgvs_c": "IDH2(NM_002168.4)c.514_516",
+                "hgvs_c": "IDH2(NM_002168.4):c.514_516",
                 "gene": "IDH2",
                 "counts_cosmic": NaN,
                 "percent_cosmic": NaN

--- a/analysis/test_data/Database_38/sample4_aitcl_coverage.json
+++ b/analysis/test_data/Database_38/sample4_aitcl_coverage.json
@@ -481,7 +481,7 @@
                 "chr": 15,
                 "pos_start": 90088604,
                 "pos_end": 90088607,
-                "hgvs_c": "IDH2(NM_002168.4)c.514_516",
+                "hgvs_c": "IDH2(NM_002168.4):c.514_516",
                 "gene": "IDH2",
                 "counts_cosmic": NaN,
                 "percent_cosmic": NaN

--- a/analysis/test_data/Database_38/sample5_aitcl_coverage.json
+++ b/analysis/test_data/Database_38/sample5_aitcl_coverage.json
@@ -480,7 +480,7 @@
                 "chr": 15,
                 "pos_start": 90088604,
                 "pos_end": 90088607,
-                "hgvs_c": "IDH2(NM_002168.4)c.514_516",
+                "hgvs_c": "IDH2(NM_002168.4):c.514_516",
                 "gene": "IDH2",
                 "counts_cosmic": NaN,
                 "percent_cosmic": NaN
@@ -491,7 +491,7 @@
                 "chr": 3,
                 "pos_start": 49375532,
                 "pos_end": 49375535,
-                "hgvs_c": "RHOA(NM_001664.4)c.55_57",
+                "hgvs_c": "RHOA(NM_001664.4):c.55_57",
                 "gene": "IDH2",
                 "counts_cosmic": NaN,
                 "percent_cosmic": NaN
@@ -500,7 +500,7 @@
                 "chr": 3,
                 "pos_start": 49375535,
                 "pos_end": 49375538,
-                "hgvs_c": "RHOA(NM_001664.4)c.52_54",
+                "hgvs_c": "RHOA(NM_001664.4):c.52_54",
                 "gene": "IDH2",
                 "counts_cosmic": NaN,
                 "percent_cosmic": NaN
@@ -509,7 +509,7 @@
                 "chr": 3,
                 "pos_start": 49375538,
                 "pos_end": 49375541,
-                "hgvs_c": "RHOA(NM_001664.4)c.49_51",
+                "hgvs_c": "RHOA(NM_001664.4):c.49_51",
                 "gene": "IDH2",
                 "counts_cosmic": NaN,
                 "percent_cosmic": NaN
@@ -518,7 +518,7 @@
                 "chr": 15,
                 "pos_start": 90088604,
                 "pos_end": 90088607,
-                "hgvs_c": "IDH2(NM_002168.4)c.514_516",
+                "hgvs_c": "IDH2(NM_002168.4):c.514_516",
                 "gene": "IDH2",
                 "counts_cosmic": NaN,
                 "percent_cosmic": NaN

--- a/analysis/test_data/Database_38/sample6_aitcl_coverage.json
+++ b/analysis/test_data/Database_38/sample6_aitcl_coverage.json
@@ -480,7 +480,7 @@
                 "chr": 15,
                 "pos_start": 90088604,
                 "pos_end": 90088607,
-                "hgvs_c": "IDH2(NM_002168.4)c.514_516",
+                "hgvs_c": "IDH2(NM_002168.4):c.514_516",
                 "gene": "IDH2",
                 "counts_cosmic": NaN,
                 "percent_cosmic": NaN
@@ -491,7 +491,7 @@
                 "chr": 3,
                 "pos_start": 49375532,
                 "pos_end": 49375535,
-                "hgvs_c": "RHOA(NM_001664.4)c.55_57",
+                "hgvs_c": "RHOA(NM_001664.4):c.55_57",
                 "gene": "IDH2",
                 "counts_cosmic": NaN,
                 "percent_cosmic": NaN
@@ -500,7 +500,7 @@
                 "chr": 3,
                 "pos_start": 49375535,
                 "pos_end": 49375538,
-                "hgvs_c": "RHOA(NM_001664.4)c.52_54",
+                "hgvs_c": "RHOA(NM_001664.4):c.52_54",
                 "gene": "IDH2",
                 "counts_cosmic": NaN,
                 "percent_cosmic": NaN
@@ -509,7 +509,7 @@
                 "chr": 3,
                 "pos_start": 49375538,
                 "pos_end": 49375541,
-                "hgvs_c": "RHOA(NM_001664.4)c.49_51",
+                "hgvs_c": "RHOA(NM_001664.4):c.49_51",
                 "gene": "IDH2",
                 "counts_cosmic": NaN,
                 "percent_cosmic": NaN
@@ -518,7 +518,7 @@
                 "chr": 15,
                 "pos_start": 90088604,
                 "pos_end": 90088607,
-                "hgvs_c": "IDH2(NM_002168.4)c.514_516",
+                "hgvs_c": "IDH2(NM_002168.4):c.514_516",
                 "gene": "IDH2",
                 "counts_cosmic": NaN,
                 "percent_cosmic": NaN

--- a/analysis/test_data/Database_38/sample7_aitcl_coverage.json
+++ b/analysis/test_data/Database_38/sample7_aitcl_coverage.json
@@ -480,7 +480,7 @@
                 "chr": 15,
                 "pos_start": 90088604,
                 "pos_end": 90088607,
-                "hgvs_c": "IDH2(NM_002168.4)c.514_516",
+                "hgvs_c": "IDH2(NM_002168.4):c.514_516",
                 "gene": "IDH2",
                 "counts_cosmic": NaN,
                 "percent_cosmic": NaN
@@ -491,7 +491,7 @@
                 "chr": 15,
                 "pos_start": 90088604,
                 "pos_end": 90088607,
-                "hgvs_c": "IDH2(NM_002168.4)c.514_516",
+                "hgvs_c": "IDH2(NM_002168.4):c.514_516",
                 "gene": "IDH2",
                 "counts_cosmic": NaN,
                 "percent_cosmic": NaN

--- a/analysis/utils.py
+++ b/analysis/utils.py
@@ -679,48 +679,34 @@ def get_coverage_data(sample_obj, depth_cutoffs):
             else:
                 counts_cosmic = 'N/A'
 
+            # make temp dict of info for each gap
+            gaps_dict = {
+                'genomic': gap.genomic(),
+                'gene': gap.hgvs_c.split('(')[0],
+                'hgvs_c': gap.hgvs_c.split(':')[1],
+                'percent_cosmic': percent_cosmic,
+                'counts_cosmic': counts_cosmic,
+            }
+
+            # add the dict to the list for the correct coverage cutoff
             # gaps at 135x
             if gap.coverage_cutoff == 135:
                 gaps_present_135 = True
-                gaps_dict = {
-                    'genomic': gap.genomic(),
-                    'hgvs_c': gap.hgvs_c,
-                    'percent_cosmic': percent_cosmic,
-                    'counts_cosmic': counts_cosmic,
-                }
                 gaps_135.append(gaps_dict)
 
             # gaps at 270x
             elif gap.coverage_cutoff == 270:
                 gaps_present_270 = True
-                gaps_dict = {
-                    'genomic': gap.genomic(),
-                    'hgvs_c': gap.hgvs_c,
-                    'percent_cosmic': percent_cosmic,
-                    'counts_cosmic': counts_cosmic,
-                }
                 gaps_270.append(gaps_dict)
 
             # gaps at 500x
             elif gap.coverage_cutoff == 500:
                 gaps_present_500 = True
-                gaps_dict = {
-                    'genomic': gap.genomic(),
-                    'hgvs_c': gap.hgvs_c,
-                    'percent_cosmic': gap.percent_cosmic,
-                    'counts_cosmic': counts_cosmic,
-                }
                 gaps_500.append(gaps_dict)
 
             # gaps at 1000x
             elif gap.coverage_cutoff == 1000:
                 gaps_present_1000 = True
-                gaps_dict = {
-                    'genomic': gap.genomic(),
-                    'hgvs_c': gap.hgvs_c,
-                    'percent_cosmic': percent_cosmic,
-                    'counts_cosmic': counts_cosmic,
-                }
                 gaps_1000.append(gaps_dict)
 
         # combine gaps and regions dictionaries

--- a/analysis/utils.py
+++ b/analysis/utils.py
@@ -332,6 +332,7 @@ def get_variant_info(sample_data, sample_obj):
     variant_calls = []
     reportable_list = []
     filtered_list = []
+    other_calls_list = []
     poly_count = 0
     artefact_count = 0
 
@@ -409,6 +410,10 @@ def get_variant_info(sample_data, sample_obj):
         if sample_variant.variant_instance.get_final_decision_display() in ['Genuine']:
             reportable_list.append(variant_obj.variant)
 
+        # list of other calls to go in the footer of the report
+        if sample_variant.variant_instance.get_final_decision_display() in ['Miscalled', 'Failed call']:
+            other_calls_list.append(f'{sample_variant.variant_instance.gene} {sample_variant.variant_instance.hgvs_c}')
+
         # get list of comments for variant
         variant_comments_list = []
         for v in variant_checks:
@@ -485,6 +490,12 @@ def get_variant_info(sample_data, sample_obj):
     else:
         no_calls = False
 
+    # make list of other calls to go in footer of PDF report
+    if len(other_calls_list) == 0:
+        other_calls_text = 'None'
+    else:
+        other_calls_text = ', '.join(other_calls_list)
+
     # return as variantr data dictionary
     variant_data = {
         'variant_calls': variant_calls, 
@@ -492,6 +503,7 @@ def get_variant_info(sample_data, sample_obj):
         'poly_count': poly_count,
         'artefact_count': artefact_count,
         'no_calls': no_calls,
+        'other_calls_text': other_calls_text,
         'check_options': VariantCheck.DECISION_CHOICES,
     }
 
@@ -508,6 +520,7 @@ def get_fusion_info(sample_data, sample_obj):
     fusion_calls = []
     reportable_list = []
     filtered_list = []
+    other_calls_list = []
     artefact_count = 0
 
     for fusion_object in fusions:
@@ -549,8 +562,12 @@ def get_fusion_info(sample_data, sample_obj):
                 )
 
         # if variant is to appear on report tab, add to list
-        if fusion_object.fusion_instance.get_final_decision_display() in ['Genuine', 'Miscalled']:
+        if fusion_object.fusion_instance.get_final_decision_display() in ['Genuine']:
             reportable_list.append(fusion_object)
+
+        # list of other calls to go in the footer of the report
+        if fusion_object.fusion_instance.get_final_decision_display() in ['Miscalled', 'Failed call']:
+            other_calls_list.append(fusion_object.fusion_instance.fusion_genes.fusion_genes)
 
         # only get VAF when panel setting says so, otherwise return none
         panel = sample_obj.panel
@@ -611,11 +628,18 @@ def get_fusion_info(sample_data, sample_obj):
     else:
         no_calls = False
 
+        # make list of other calls to go in footer of PDF report
+    if len(other_calls_list) == 0:
+        other_calls_text = 'None'
+    else:
+        other_calls_text = ', '.join(other_calls_list)
+
     fusion_data = {
         'fusion_calls': fusion_calls,
         'filtered_calls': filtered_list,
         'artefact_count': artefact_count,
         'no_calls': no_calls,
+        'other_calls_text': other_calls_text,
         'check_options': FusionCheck.DECISION_CHOICES,
     }
 

--- a/analysis/utils.py
+++ b/analysis/utils.py
@@ -108,7 +108,7 @@ def reopen_check(current_user, sample_analysis_obj):
     sample_analysis_obj.save()
 
     return True
-        
+
 
 @transaction.atomic
 def signoff_check(user, current_step_obj, sample_obj, status='C', complete=False):
@@ -406,7 +406,7 @@ def get_variant_info(sample_data, sample_obj):
                 last_two_checks_agree = False
 
         # if variant is to appear on report tab, add to list
-        if sample_variant.variant_instance.get_final_decision_display() in ['Genuine', 'Miscalled']:
+        if sample_variant.variant_instance.get_final_decision_display() in ['Genuine']:
             reportable_list.append(variant_obj.variant)
 
         # get list of comments for variant
@@ -1010,8 +1010,8 @@ def get_fusion_list(artefact_list_obj, user):
             checking_list.append(formatted_variant)
 
     return confirmed_list, checking_list
-  
-    
+
+
 def if_nucleotide(string):
     """
     Function to check if nucleotide is a string


### PR DESCRIPTION
Fix issue #90 

- Added a `report_snv_vaf` field to the panels model, which will control whether VAF is exported to the LIMS XML or not
- Changed the XML template so that VAF is blank if `report_snv_vaf` is False
- Split the gap description into gene and HGVSc so they can be separate fields on the LIMS XML (transcript no longer included but that's fine)
- Tidied up the gaps display on the depth tab, it was different for different depth cutoffs
- Fixed test data so that the gap description is in the correct format, there was a bug in the pipeline where it was missing a colon which has since been fixed, the data must have been generated before the bug fix
- Only output genuine variants to the report tab, PDF and XML. 
- Add a sentence saying this to the report tab and PDF
- Add a list of failed/miscalled calls to the PDF so checkers can know if they might want to go back into the SVD to look into them