### PR TITLE
docs: Correct poly lists command in quick_install.md and incorrect links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ A database for analysing cancer NGS data within AWMGS
 
 ## Links 
 
-- [Quick start guide](https://awgl.github.io/somatic_db/developer_guide/quick_install/)
-- [Troubleshooting](https://awgl.github.io/somatic_db/developer_guide/common_errors/)
-- [Unit testing](https://awgl.github.io/somatic_db/developer_guide/unit_tests/)
+- [Quick start guide](https://awgl.github.io/somatic_db/#/developer_guide/quick_install)
+- [Troubleshooting](https://awgl.github.io/somatic_db/#/developer_guide/common_errors)
+- [Unit testing](https://awgl.github.io/somatic_db/#/developer_guide/unit_tests)
 - [Full documentation (user & developer guide)](https://awgl.github.io/somatic_db/)

--- a/docs/developer_guide/quick_install.md
+++ b/docs/developer_guide/quick_install.md
@@ -43,8 +43,8 @@ python manage.py loaddata variant_lists.json
 
 Optional - Load in poly lists (`--both_checks` flag will bypass the need for two checks on each poly, for dev work only):
 ```
-python manage.py add_poly_list --list roi/b37_polys.txt --genome 37 --both_checks
-python manage.py add_poly_list --list roi/b38_polys.txt --genome 38 --both_checks
+python manage.py add_poly_list --list build_37_polys --variants roi/b37_polys.txt --both_checks
+python manage.py add_poly_list --list build_38_polys --variants roi/b38_polys.txt --both_checks
 ```
 
 Optional - Load in test cases:


### PR DESCRIPTION
Closes #138
Fix #139

**Description:**  
This PR updates the `quick_install.md` documentation to correct the commands for loading poly lists during installation and  addresses the issue of broken and outdated links in the `README.md` file.

**Changes:**  
- Updated the commands for adding poly lists in the install guide to use the correct flags:
  - Changed from:
    ```bash
    python manage.py add_poly_list --list roi/b37_polys.txt --genome 37 --both_checks
    python manage.py add_poly_list --list roi/b38_polys.txt --genome 38 --both_checks
    ```
  - To:
    ```bash
    python manage.py add_poly_list --list build_37_polys --variants roi/b37_polys.txt --both_checks
    python manage.py add_poly_list --list build_38_polys --variants roi/b38_polys.txt --both_checks
    ```

- Corrected the following broken links in the README:
  - [https://awgl.github.io/somatic_db/developer_guide/quick_install/](https://awgl.github.io/somatic_db/developer_guide/quick_install/) was updated to [https://awgl.github.io/somatic_db/#/developer_guide/quick_install](https://awgl.github.io/somatic_db/#/developer_guide/quick_install)
  - [https://awgl.github.io/somatic_db/developer_guide/common_errors/](https://awgl.github.io/somatic_db/developer_guide/common_errors/) was updated to [https://awgl.github.io/somatic_db/#/developer_guide/common_errors](https://awgl.github.io/somatic_db/#/developer_guide/common_errors)
  - [https://awgl.github.io/somatic_db/developer_guide/unit_tests/](https://awgl.github.io/somatic_db/developer_guide/unit_tests/) was updated to [https://awgl.github.io/#/somatic_db/developer_guide/unit_tests](https://awgl.github.io/#/somatic_db/developer_guide/unit_tests)
- Verified that all references in the README point to the most current documentation.


